### PR TITLE
CI: Attempt to use bundler-cache

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,9 +10,8 @@ jobs:
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 3.0.0
+        ruby-version: "3.0"
+        bundler-cache: true # 'bundle install' and cache        
     - name: Run the default task
       run: |
-        gem install bundler -v 2.2.11
-        bundle install
         bundle exec rake


### PR DESCRIPTION
Went with the two-part Ruby version, too, since the Action adds 'latest known patch number' onto it.

Ah, I can see that the bigger issue is that the other repos in the Gemfile are not checked out.